### PR TITLE
Correção no método Right do Extensions.cs

### DIFF
--- a/src/Boleto.Net/Util/Extensions.cs
+++ b/src/Boleto.Net/Util/Extensions.cs
@@ -90,7 +90,7 @@ namespace BoletoNet.Util
 
         public static string Right(this string str, int length)
         {
-            return str.Substring(str.Length - length);
+            return str.Substring(length >= str.Length ? str : str.Length - length);
         }
 
     }


### PR DESCRIPTION
Eu havia identificado há um tempo atrás em qual revisão havia sido criado este método, porém não me lembro.

Resumindo: O método Strings.Right antigamente utilizava o namespace Microsoft.VisualBasic, sendo que atualmente não é mais utilizado. 
E  o método Strings.Right é utilizado na geração da remessa do Bradesco, o qual está ocorrendo erro quando o tamanho do parâmetro "str" é menor que o parâmetro "length" passado.